### PR TITLE
Fixed bad config file flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN go build -o rssmq ./main.go
 
 FROM alpine:3.15.0 as final-stage
 COPY --from=go-build-stage /src/rssmq /rssmq
-CMD /rssmq
+CMD /rssmq --config /opt/rssmq.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     build: .
     image: rssmq
     restart: unless-stopped
+    volumes:
+      - ./rssmq.json:/opt/rssmq.json


### PR DESCRIPTION
Set container to default use the `--config` flag to point to `/opt/rssmq.json`.

Closes #112